### PR TITLE
[extracting_inertial_parameters.cpp] Updated the example.

### DIFF
--- a/cmake/vrep_interface_tests/extracting_inertial_parameters/extracting_inertial_parameters.cpp
+++ b/cmake/vrep_interface_tests/extracting_inertial_parameters/extracting_inertial_parameters.cpp
@@ -202,8 +202,8 @@ int main(void)
             inertia_list.block(j*3, k*3, 3,3) = I_DH_frame;
 
             //compute the center of mass of each link expressed in the absolute frame.
-            VectorXd com0 = vi.get_center_of_mass(link, DQ_VrepInterface::ABSOLUTE_FRAME);
-            DQ xcom0 = 1+ E_*0.5*DQ(0,com0(0), com0(1), com0(2));
+            DQ pcom0 = vi.get_center_of_mass(link, DQ_VrepInterface::ABSOLUTE_FRAME);
+            DQ xcom0 = 1+ E_*0.5*pcom0;
 
             //We compute the constant rigid transformation of the center of mass with respect to the DH frames.
             VectorXd vecxc = vec3(translation(xi.conj()*xcom0));


### PR DESCRIPTION
Hi @mmmarinho 

This PR updates the get_center_of_mass() method in " extracting_inertial_parameters.cpp" according to [this PR.](https://github.com/dqrobotics/cpp-interface-vrep/pull/4)

Best regards, 

Juancho