### PR TITLE
[qpoasse_interface test] PR added check for equality constraints 

### DIFF
--- a/cmake/qpoases_interface/qpoases_interface.cpp
+++ b/cmake/qpoases_interface/qpoases_interface.cpp
@@ -75,7 +75,7 @@ void test_equality(void) {
 
     for (int problem_size = 5; problem_size <= 10; problem_size += 1) {
         qpoases_solver = DQ_QPOASESSolver();
-        auto tolerance = qpoases_solver.get_equality_constraints_tolerance();
+        tolerance = qpoases_solver.get_equality_constraints_tolerance();
         qpoases_solver.set_equality_constraints_tolerance(tolerance);
 
         MatrixXd H = MatrixXd::Identity(problem_size, problem_size);
@@ -90,6 +90,7 @@ void test_equality(void) {
             MatrixXd Aeq = mlp.asDiagonal();
             VectorXd beq = VectorXd::Random(problem_size);
             auto out = qpoases_solver.solve_quadratic_program(H, f, A, b, Aeq, beq);
+            // just plain tolerance is too tight for the check
             if (!are_vectors_equal(beq, Aeq * out, tolerance+DQ_threshold)) {
                 std::cout << "Solver Failed equality check on mlp: " << mlp.transpose() <<
                           std::endl << "beq: " << beq.transpose() <<

--- a/cmake/qpoases_interface/qpoases_interface.cpp
+++ b/cmake/qpoases_interface/qpoases_interface.cpp
@@ -30,26 +30,87 @@ Contributors:
 
 using namespace DQ_robotics;
 
-int main(void)
-{
+void test_solver(void) {
     DQ_QPOASESSolver qpoases_solver;
     DQ_SerialManipulatorDH robot = KukaLw4Robot::kinematics();
 
-    DQ_ClassicQPController classic_qp_controller(&robot,&qpoases_solver);
+    DQ_ClassicQPController classic_qp_controller(&robot, &qpoases_solver);
     classic_qp_controller.set_control_objective(ControlObjective::Pose);
     classic_qp_controller.set_gain(0.01);
     classic_qp_controller.set_damping(0.01);
 
     VectorXd theta_init(7);
-    theta_init << 0.,pi/4.,0.,0.,pi/4.,0.,0.;
+    theta_init << 0., pi / 4., 0., 0., pi / 4., 0., 0.;
 
     VectorXd theta_xd(7);
-    theta_xd << 0.,pi/2.,0.,0.,pi/2.,0.,0.;
+    theta_xd << 0., pi / 2., 0., 0., pi / 2., 0., 0.;
     DQ xd = robot.fkm(theta_xd);
 
-    VectorXd qd = classic_qp_controller.compute_setpoint_control_signal(theta_init,vec8(xd));
+    VectorXd qd = classic_qp_controller.compute_setpoint_control_signal(theta_init, vec8(xd));
 
     std::cout << "q_dot is " << qd.transpose() << std::endl;
+}
+
+
+bool are_vectors_equal(const Eigen::VectorXd &A, const Eigen::VectorXd &B, double tolerance = 1e-3) {
+    if (A.size() != B.size()) {
+        return false; // Vectors have different dimensions
+    }
+
+    for (int i = 0; i < A.size(); ++i) {
+        if (std::abs(A(i) - B(i)) > tolerance) {
+            std::cout << "CHECK::index: " << i << " exceed error: " << std::abs(A(i) - B(i)) << std::endl;
+            return false; // Elements at (i) differ by more than the tolerance
+        }
+    }
+
+    return true;
+}
+
+void test_equality(void) {
+    DQ_QPOASESSolver qpoases_solver;
+    auto tolerance = qpoases_solver.get_equality_constraints_tolerance();
+//        tolerance = 0.001;
+    std::cout << "current equality tolerance: " << tolerance << std::endl;
+
+    for (int problem_size = 5; problem_size <= 10; problem_size += 1) {
+        qpoases_solver = DQ_QPOASESSolver();
+        auto tolerance = qpoases_solver.get_equality_constraints_tolerance();
+        qpoases_solver.set_equality_constraints_tolerance(tolerance);
+
+        MatrixXd H = MatrixXd::Identity(problem_size, problem_size);
+        VectorXd f = VectorXd::Ones(problem_size);
+
+        MatrixXd A = MatrixXd::Zero(1, problem_size);
+        VectorXd b = VectorXd::Zero(1);
+        std::cout << "Checking Problem Size: " << problem_size << std::endl;
+
+        for (int iter = 0; iter < 10; iter += 1) {
+            VectorXd mlp = VectorXd::Random(problem_size);
+            MatrixXd Aeq = mlp.asDiagonal();
+            VectorXd beq = VectorXd::Random(problem_size);
+            auto out = qpoases_solver.solve_quadratic_program(H, f, A, b, Aeq, beq);
+            if (!are_vectors_equal(beq, Aeq * out, tolerance+DQ_threshold)) {
+                std::cout << "Solver Failed equality check on mlp: " << mlp.transpose() <<
+                          std::endl << "beq: " << beq.transpose() <<
+                          std::endl << "Solution: " << out.transpose() <<
+                          std::endl << "check " << (Aeq * out).transpose() << std::endl;
+                throw std::runtime_error("solver equality check failed");
+            }
+
+        }
+
+    }
+
+
+}
+
+
+int main(void) {
+    test_solver();
+    test_equality();
 
     return 0;
 }
+
+

--- a/cmake/qpoases_interface/qpoases_interface.cpp
+++ b/cmake/qpoases_interface/qpoases_interface.cpp
@@ -18,6 +18,9 @@ This file is part of DQ Robotics.
 
 Contributors:
 - Murilo M. Marinho (murilo@g.ecc.u-tokyo.ac.jp)
+    - initial implementation
+- Quentin Lin (qlin1806@g.ecc.u-tokyo.ac.jp)
+    - added check for equality constraints
 */
 
 #include <iostream>


### PR DESCRIPTION
Hi @mmmarinho, 

This PR added test for the DQ_QPOASESSolver equality constraints check that is in tandem with the PR [#1](https://github.com/dqrobotics/cpp-interface-qpoases/pull/1) in that Repo. 
Some modification were made to the original code limited to the structure, in addition to a new `test_equality` test case. 

<img width="534" alt="Screenshot 2023-10-30 at 7 46 38 PM" src="https://github.com/dqrobotics/cpp-examples/assets/31228437/464a1e6a-4e48-4889-b14e-c0d0ea31263c">


qlin
Best,