### PR TITLE
This PR fixes the missing CMake include and updates the compatible CMake versions in the qpoases_interface example.

### DIFF
--- a/cmake/qpoases_interface/CMakeLists.txt
+++ b/cmake/qpoases_interface/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.1)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5...3.26)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../dqrobotics_dependencies.cmake)
 
 project(qpoases_interface)
 

--- a/cmake/qpoases_interface/CMakeLists.txt
+++ b/cmake/qpoases_interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.22...3.26)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.22...3.28)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../dqrobotics_dependencies.cmake)
 
 project(qpoases_interface)

--- a/cmake/qpoases_interface/CMakeLists.txt
+++ b/cmake/qpoases_interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.5...3.26)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.22...3.26)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../dqrobotics_dependencies.cmake)
 
 project(qpoases_interface)


### PR DESCRIPTION
@dqrobotics/developers 

Hi @mmmarinho,

This PR fixes the missing CMake include and updates the compatible CMake versions in the  `qpoases_interface`  example.

Context:
The example `qpoases_interface` is not compiling, and consequently, the cpp-interface-qpoases actions are [failing](https://github.com/dqrobotics/cpp-interface-qpoases/actions/runs/16726990234/job/47345152526). The problem is related to a missing include in the CMakeLists.txt file. 

Current output:

```shell
-- Build files have been written to: /home/runner/work/cpp-interface-qpoases/cpp-interface-qpoases/cpp-examples/cmake/qpoases_interface/build
[ 50%] Building CXX object CMakeFiles/qpoases_interface.dir/qpoases_interface.cpp.o
In file included from /home/runner/work/cpp-interface-qpoases/cpp-interface-qpoases/cpp-examples/cmake/qpoases_interface/qpoases_interface.cpp:28:
/usr/include/dqrobotics/DQ.h:45:10: fatal error: Eigen/Dense: No such file or directory
   45 | #include <Eigen/Dense>
      |          ^~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/qpoases_interface.dir/build.make:79: CMakeFiles/qpoases_interface.dir/qpoases_interface.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/qpoases_interface.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
Failed building qpoases_interface
Error: Process completed with exit code 1.
```

Expected output:

```shell
09:54:36: Starting /home/juanjqo/git/cpp-examples/cmake/qpoases_interface/build/Desktop_Qt_6_8_1-Debug/qpoases_interface...
q_dot is  -0.00311208   0.00617398   0.00304193   -0.0015048   0.00304193 -0.000791966   0.00304193
current equality tolerance: 1e-12
Checking Problem Size: 5
Checking Problem Size: 6
Checking Problem Size: 7
Checking Problem Size: 8
Checking Problem Size: 9
Checking Problem Size: 10
```

Kind regards, 


Juancho